### PR TITLE
HDX-5872 - [quick charts 2] When changing recipes on dataset page - o…

### DIFF
--- a/src/app/bites/bite-list/bite-list.component.ts
+++ b/src/app/bites/bite-list/bite-list.component.ts
@@ -369,13 +369,13 @@ export class BiteListComponent implements OnInit {
   getEmbedLink() {
     const customCookbookURL = this.showCustomCookbookControls ? this.customCookbookUrl : null;
     return this.biteService.exportBitesToURL(this.biteList, customCookbookURL,
-              this.cookbooksAndTags.chosenCookbook.name, false);
+              this.getChosenCookbookName(), false);
   }
 
   saveAsImage() {
     const customCookbookURL = this.showCustomCookbookControls ? this.customCookbookUrl : null;
     return this.biteService.exportBitesToURL(this.biteList, customCookbookURL,
-              this.cookbooksAndTags.chosenCookbook.name, false);
+              this.getChosenCookbookName(), false);
   }
 
 
@@ -397,6 +397,7 @@ export class BiteListComponent implements OnInit {
 
     } else if (payload.name === 'show-recipe-section') {
       this.showCookbookControls = payload.checked;
+      window.parent.postMessage(`iframe-height-update`, '*');
     }
   }
 


### PR DESCRIPTION
…nly 1 or 2 chart is displayed.

         - choosen cookbook name bug - if HXL Preview is included in iframe, the getEmbeddedLink event seems to get called before the cookbook is set