### PR TITLE
Forcing specific version of angular-cli global

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 
 COPY . .
 
-RUN npm install -g @angular/cli && \
+RUN npm install -g @angular/cli@7.0.6 && \
     npm install && \
     ng build --prod --aot --base-href $BASE_HREF/ && \
     cp -a docker/default.conf dist && \


### PR DESCRIPTION
avoiding exception below:
"You are running version v8.11.3 of Node.js,
 which is not supported by Angular CLI 8.0+"